### PR TITLE
docs: Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The server stores only the following information:
 
 ## API Endpoints
 
-This server is hostet at `https://analytics.pocket-id.org`.
+This server is hosted at `https://analytics.pocket-id.org`.
 
 ### Get Statistics
 


### PR DESCRIPTION
Fixes a typo in the README.

changed "hostet" to "hosted"